### PR TITLE
fix trajectory unvisualized problem for CartesianPath planning

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -143,6 +143,8 @@ void MotionPlanningFrame::computeCartecianPlanButtonClicked()
   moveit_msgs::RobotTrajectory trajectory;
   double fraction =
       move_group_->computeCartesianPath(waypoints, cart_step_size, cart_jump_thresh, trajectory, avoid_collisions);
+  Q_EMIT planningFinished();
+
   if (fraction > 0)
   {
     // Success
@@ -180,7 +182,6 @@ void MotionPlanningFrame::computeCartecianPlanButtonClicked()
     ui_->result_label->setText("Failed");
     ROS_WARN("Failed to compute CartesianPath");
   }
-  Q_EMIT planningFinished();
 }
 
 void MotionPlanningFrame::computeJointSpacePlanButtonClicked()


### PR DESCRIPTION
### Description

This PR fixes the problem that cartesian trajectory was not visualized after planning.
This problem does not occur when `Loop Animation` is True.

**The cause of the problem**
`interruptCurrentDisplay()` is called at `Q_EMIT planningFinished()` line in `computeCartecianPlanButtonClicked()`.
https://github.com/ros-planning/moveit/blob/kinetic-devel/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp#L229
`interruptCurrentDisplay()` disables the current visualizing animation (i.e. `current_state_ > 0`).
https://github.com/ros-planning/moveit/blob/kinetic-devel/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp#L321-L328
`current_state_` is initialized with -1 when planning is succeeded, and incremented to 0, 1, 2, ... while animation proceeds.
https://github.com/ros-planning/moveit/blob/kinetic-devel/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp#L398

If `interruptCurrentDisplay()` is called from `Q_EMIT planningFinished()` line just after planning is succeeded (i.e. while `current_state_` is -1 or 0), `interruptCurrentDisplay()` disables previous animation. But it disables current animation after `current_state_` is incremented to larger than 1. 
The following time scaling lines takes time that can not be ignored, so the latest animation is disabled.
https://github.com/k-okada/moveit/blob/cartecian_path/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp#L148-L175
So the sample problem occurs if we put `ros::Duration(0.5).sleep();` just before `Q_EMIT planningFinished()` even in non-cartesian planning `computeJointSpacePlanButtonClicked`.

This PR solution is moving `Q_EMIT planningFinished()` to right after the planning. This was ad-hoc but best way I could think of.


**before this PR**
Cartesian path is not visualized.
![moveit-cartecian-visualization-before-fix-small](https://user-images.githubusercontent.com/6636600/44398529-1ebe0780-a57f-11e8-9d59-30b0d9bcc717.gif)

**after this PR**
Cartesian path is visualized correctly.
![moveit-cartecian-visualization-after-fix-small](https://user-images.githubusercontent.com/6636600/44398534-22ea2500-a57f-11e8-892a-1af64cc5e20b.gif)

### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)